### PR TITLE
Fix PostgreSQL platform check

### DIFF
--- a/Classes/Domain/Repository/FileRepository.php
+++ b/Classes/Domain/Repository/FileRepository.php
@@ -73,7 +73,7 @@ class FileRepository
         if ($platform instanceof DoctrineMySQLPlatform) {
             return 'mysql';
         }
-        if ($platform instanceof DoctrinePostgreSqlPlatform) {
+        if ($platform instanceof DoctrinePostgreSQLPlatform) {
             return 'postgresql';
         }
         if ($platform instanceof DoctrineSQLitePlatform) {


### PR DESCRIPTION
## Summary
- fix typo in FileRepository when detecting PostgreSQL platforms

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68446082c994832989ff86bd911c0077